### PR TITLE
Add CI and regression test foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Check formatting
+        run: yarn prettify
+
+      - name: Run tests
+        run: yarn test --watchAll=false
+        env:
+          CI: true
+
+      - name: Build application
+        run: yarn build

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import App from "./App";
+
+jest.mock("axios", () => ({
+  get: () => Promise.resolve({ data: "" }),
+}));
+
+const renderRoute = (route: string) => {
+  window.history.pushState({}, "", route);
+  return render(<App />);
+};
+
+describe("App", () => {
+  it("renders the main navigation", () => {
+    renderRoute("/");
+
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "About" })).toHaveAttribute("href", "/about-me");
+    expect(screen.getByRole("link", { name: "CV" })).toHaveAttribute("href", "/cv");
+    expect(screen.getByRole("link", { name: "Chess" })).toHaveAttribute("href", "/chess");
+  });
+
+  it.each([
+    ["/", "Hi, I'm Guy Green"],
+    ["/about-me", "About Me"],
+    ["/cv", "Curriculum Vitae"],
+    ["/chess", "My Chess Life"],
+  ])("renders the %s route", (route, heading) => {
+    renderRoute(route);
+
+    expect(screen.getByRole("heading", { level: 1, name: heading })).toBeInTheDocument();
+  });
+
+  it("renders the current employment and ambassadorship content", () => {
+    renderRoute("/cv");
+
+    expect(screen.getByRole("heading", { name: /Oracle.*Software Engineer/ })).toBeInTheDocument();
+    expect(screen.getByText(/Ambassador for GreenPoint Virgin Active Padel/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/AboutMePage/AboutMePage.tsx
+++ b/src/pages/AboutMePage/AboutMePage.tsx
@@ -41,15 +41,17 @@ const AboutMePage: React.FC = () => {
 
       {/* Image Gallery */}
       <section className="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        {["1.jpeg", "2.jpeg", "3.jpeg", "4.jpeg", "5.jpeg", "6.jpeg", "7.jpeg","profile.jpg"].map((imgName, idx) => (
-          <div key={idx} className="overflow-hidden rounded-lg shadow-lg">
-            <img
-              src={require(`../../assets/images/${imgName}`)}
-              alt={`About Me ${idx + 1}`}
-              className="w-full h-48 object-cover transform hover:scale-105 transition duration-300"
-            />
-          </div>
-        ))}
+        {["1.jpeg", "2.jpeg", "3.jpeg", "4.jpeg", "5.jpeg", "6.jpeg", "7.jpeg", "profile.jpg"].map(
+          (imgName, idx) => (
+            <div key={idx} className="overflow-hidden rounded-lg shadow-lg">
+              <img
+                src={require(`../../assets/images/${imgName}`)}
+                alt={`About Me ${idx + 1}`}
+                className="w-full h-48 object-cover transform hover:scale-105 transition duration-300"
+              />
+            </div>
+          )
+        )}
       </section>
     </div>
   );

--- a/src/utils/lichessUtils.test.ts
+++ b/src/utils/lichessUtils.test.ts
@@ -1,0 +1,17 @@
+import { extractLichessGameIds } from "./lichessUtils";
+
+describe("extractLichessGameIds", () => {
+  it("extracts game IDs in response order", () => {
+    const response = [
+      '{"id":"first-game","rated":true}',
+      '{"id":"second-game","rated":false}',
+    ].join("\n");
+
+    expect(extractLichessGameIds(response)).toEqual(["first-game", "second-game"]);
+  });
+
+  it("returns an empty array when the response has no games", () => {
+    expect(extractLichessGameIds("")).toEqual([]);
+    expect(extractLichessGameIds("not a Lichess response")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add route and navigation regression tests for the current application
- assert the current employment and Virgin Active Padel content
- add unit coverage for Lichess game ID extraction
- run formatting, tests, and production builds in GitHub Actions
- use Node.js 20 and the locked Yarn dependencies in CI

## Verification
- 2 test suites passed
- 8 tests passed
- production build completed successfully
- changed files pass Prettier
- git diff --check passed

## Notes
Feature-specific tests for Projects and FootyBru are intentionally deferred to their feature PRs so they can be developed with TDD.

Closes #11