### PR TITLE
Fix Chess page request state handling

### DIFF
--- a/src/components/Tab/TabContent/RecentGamesContent.tsx
+++ b/src/components/Tab/TabContent/RecentGamesContent.tsx
@@ -2,17 +2,17 @@ import React from "react";
 import { embeddedLichessUrl } from "../../../constants/lichessConstants";
 
 interface RecentGamesContentProps {
-  gamesIds: String[];
+  gameIds: string[];
 }
 
-const RecentGamesContent: React.FC<RecentGamesContentProps> = ({ gamesIds }) => {
+const RecentGamesContent: React.FC<RecentGamesContentProps> = ({ gameIds }) => {
   return (
     <div className="space-y-8">
       <h2 className="text-3xl md:text-4xl font-bold text-center mb-6">My Recent Online Games</h2>
 
       <div className="flex flex-col items-center gap-8">
-        {gamesIds?.map((game, index) => (
-          <div key={index} className="w-full max-w-3xl shadow-lg rounded-lg overflow-hidden">
+        {gameIds.map((game, index) => (
+          <div key={game} className="w-full max-w-3xl shadow-lg rounded-lg overflow-hidden">
             <iframe
               src={embeddedLichessUrl(game)}
               className="w-full h-[397px] md:h-[450px] border-0"

--- a/src/constants/lichessConstants.ts
+++ b/src/constants/lichessConstants.ts
@@ -1,4 +1,4 @@
 export const numberOfRecentGamesShown = 6;
 
-export const embeddedLichessUrl = (id: String) =>
+export const embeddedLichessUrl = (id: string) =>
   `https://lichess.org/embed/${id}?theme=auto&bg=auto`;

--- a/src/pages/ChessPage/ChessPage.test.tsx
+++ b/src/pages/ChessPage/ChessPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ChessPage from "./ChessPage";
+
+const axiosMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    get: axiosMocks.get,
+  },
+}));
+
+describe("ChessPage", () => {
+  beforeEach(() => {
+    axiosMocks.get.mockReset();
+  });
+
+  it("shows a loading state while recent games are being requested", () => {
+    axiosMocks.get.mockReturnValue(new Promise(() => undefined));
+
+    render(<ChessPage />);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows every returned game when Lichess returns fewer than the requested maximum", async () => {
+    axiosMocks.get.mockResolvedValue({
+      data: ['{"id":"first-game"}', '{"id":"second-game"}'].join("\n"),
+    });
+
+    render(<ChessPage />);
+
+    expect(await screen.findByTitle("Lichess game 1")).toHaveAttribute(
+      "src",
+      expect.stringContaining("first-game")
+    );
+    expect(screen.getByTitle("Lichess game 2")).toHaveAttribute(
+      "src",
+      expect.stringContaining("second-game")
+    );
+    expect(screen.queryByTitle("Lichess game 3")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when Lichess returns no games", async () => {
+    axiosMocks.get.mockResolvedValue({ data: "" });
+
+    render(<ChessPage />);
+
+    expect(await screen.findByText("No recent games are available.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+
+  it("shows an error when recent games cannot be loaded", async () => {
+    axiosMocks.get.mockRejectedValue(new Error("Network unavailable"));
+
+    render(<ChessPage />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Recent games could not be loaded. Please try again later."
+    );
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ChessPage/ChessPage.tsx
+++ b/src/pages/ChessPage/ChessPage.tsx
@@ -9,39 +9,55 @@ import LinksContent from "../../components/Tab/TabContent/LinksContent";
 import Loader from "../../components/Loader/Loader";
 
 const ChessPage: React.FC = () => {
-  const [games, setGames] = React.useState<String>("");
-  const [gamesIds, setGamesIds] = React.useState<String[]>([]);
-  const [loaded, setLoaded] = React.useState<boolean>(false);
+  const [gameIds, setGameIds] = React.useState<string[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const [displayTab, setDisplayTab] = React.useState<number>(ChessPageTabs.RecentGames);
 
   React.useEffect(() => {
     const fetchGames = async () => {
       try {
-        const response = await axios.get(
+        const response = await axios.get<string>(
           `https://lichess.org/api/games/user/guygreenInClassAtUCT?max=${numberOfRecentGamesShown}`
         );
-        setGames(response.data);
-      } catch (error) {
-        console.error("Error fetching games:", error);
+        setGameIds(extractLichessGameIds(response.data));
+      } catch {
+        setError("Recent games could not be loaded. Please try again later.");
+      } finally {
+        setIsLoading(false);
       }
     };
     fetchGames();
   }, []);
 
-  React.useEffect(() => {
-    if (games?.length > 0) {
-      setGamesIds(extractLichessGameIds(games));
+  const renderRecentGames = () => {
+    if (isLoading) {
+      return <Loader />;
     }
-  }, [games]);
 
-  if (gamesIds.length === numberOfRecentGamesShown && !loaded) {
-    setLoaded(true);
-  }
+    if (error) {
+      return (
+        <p role="alert" className="py-20 text-center text-lg font-medium text-red-600">
+          {error}
+        </p>
+      );
+    }
+
+    if (gameIds.length === 0) {
+      return (
+        <p className="py-20 text-center text-lg text-gray-700 dark:text-gray-300">
+          No recent games are available.
+        </p>
+      );
+    }
+
+    return <RecentGamesContent gameIds={gameIds} />;
+  };
 
   const renderTabs = () => {
     switch (displayTab) {
       case ChessPageTabs.RecentGames:
-        return loaded ? <RecentGamesContent gamesIds={gamesIds} /> : <Loader />;
+        return renderRecentGames();
       case ChessPageTabs.links:
         return <LinksContent />;
       default:

--- a/src/utils/lichessUtils.ts
+++ b/src/utils/lichessUtils.ts
@@ -1,7 +1,2 @@
-export const extractLichessGameIds: (pgnResponse: String) => String[] = (pgnResponse) => {
-  let gameIds: String[] = [];
-
-  gameIds = Array.from(pgnResponse.matchAll(/{"id":"(.*?)"/g)).map((match) => match[1]);
-
-  return gameIds;
-};
+export const extractLichessGameIds = (pgnResponse: string): string[] =>
+  Array.from(pgnResponse.matchAll(/{"id":"(.*?)"/g)).map((match) => match[1]);


### PR DESCRIPTION
## Summary
- remove the Chess page state update that occurred during rendering
- replace coupled response and loaded state with explicit loading, error, and game ID state
- show partial Lichess results without waiting for the requested maximum
- add clear empty and API-error states
- replace boxed String types with native string types
- use stable game IDs as rendered keys
- add focused Chess page request-state tests

## TDD
- Red: partial-result, empty-result, and request-error tests remained stuck on the loader
- Green: a single request effect and explicit states made all four scenarios pass
- Refactor: simplified ID extraction and normalized gameIds naming

## Verification
- 3 test files and 15 tests passed
- TypeScript project build passed
- Vite production build completed successfully
- touched files pass Prettier
- git diff --check passed

## Follow-up considered
The Lichess response-format contract may benefit from a separate issue. It is intentionally excluded from this PR.

Closes #19