### PR TITLE
Guard UTF-8 content rendering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json,ts,tsx}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.ico binary
+*.gif binary
+*.jpeg binary
+*.jpg binary
+*.pdf binary
+*.png binary

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -78,6 +78,6 @@ describe("App", () => {
     renderRoute(route);
 
     expect(screen.getByText(expectedText)).toBeInTheDocument();
-    expect(screen.getByText("© " + new Date().getFullYear() + " Guy Green")).toBeInTheDocument();
+    expect(screen.getByText(/^© \d{4} Guy Green$/)).toBeInTheDocument();
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -66,4 +66,18 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: /Oracle.*Software Engineer/ })).toBeInTheDocument();
     expect(screen.getByText(/Ambassador for GreenPoint Virgin Active Padel/)).toBeInTheDocument();
   });
+
+  it.each([
+    ["/", /football — which keeps me energized/],
+    ["/", /Whether it’s for work, collaboration/],
+    ["/about-me", /football — I am even an ambassador/],
+    ["/about-me", /I’m an avid F1 fan/],
+    ["/cv", "Oracle — Software Engineer"],
+    ["/cv", "April 2020 – Present"],
+  ])("renders UTF-8 punctuation correctly on %s", (route, expectedText) => {
+    renderRoute(route);
+
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+    expect(screen.getByText("© " + new Date().getFullYear() + " Guy Green")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- enforce UTF-8 and LF text settings through EditorConfig
- normalize tracked text line endings and identify binary assets through Git attributes
- add rendered-content regression coverage for copyright, apostrophes, en dashes, and em dashes
- confirm no mojibake sequences remain in visible source content

## Investigation
The affected content was already valid UTF-8 on merged main and rendered correctly through Vite. Legacy Windows PowerShell displayed UTF-8-without-BOM as mojibake, which reproduced the appearance of the original defect without reflecting browser behavior.

Because the user-visible behavior already passed, there was no honest red TDD phase to reproduce. This PR adds regression coverage and repository-level encoding safeguards instead of making artificial content changes.

## Verification
- strict byte scan: all tracked and new source/text files are valid UTF-8
- suspicious-sequence scan: no matches in visible source content
- 3 test files and 21 tests passed
- TypeScript project build passed
- Vite production build completed successfully
- changed source passes Prettier
- git diff --check passed

Closes #25