### PR TITLE
Update padel ambassadorship venue

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -60,11 +60,16 @@ describe("App", () => {
     expect(screen.getByRole("heading", { level: 1, name: heading })).toBeInTheDocument();
   });
 
-  it("renders the current employment and ambassadorship content", () => {
+  it("renders the current employment content", () => {
     renderRoute("/cv");
 
     expect(screen.getByRole("heading", { name: /Oracle.*Software Engineer/ })).toBeInTheDocument();
-    expect(screen.getByText(/Ambassador for GreenPoint Virgin Active Padel/)).toBeInTheDocument();
+  });
+
+  it.each(["/about-me", "/cv"])("renders the current padel ambassadorship on %s", (route) => {
+    renderRoute(route);
+
+    expect(screen.getByText(/ambassador for Epicenter Virgin Active Padel/i)).toBeInTheDocument();
   });
 
   it.each([

--- a/src/pages/AboutMePage/AboutMePage.tsx
+++ b/src/pages/AboutMePage/AboutMePage.tsx
@@ -31,8 +31,8 @@ const AboutMePage: React.FC = () => {
       <section className="max-w-4xl mx-auto mb-12 space-y-6">
         <p>
           I enjoy staying active and spending time outdoors. My main sports are padel, running, and
-          football — I am even an ambassador for GreenPoint Virgin Active Padel. Other sports I
-          enjoy include cricket, touch rugby, and squash.
+          football — I am even an ambassador for Epicenter Virgin Active Padel. Other sports I enjoy
+          include cricket, touch rugby, and squash.
         </p>
         <p>
           When it comes to spectating, I’m an avid F1 fan and participate in the F1 Fantasy Game

--- a/src/pages/CVPage/CVPage.tsx
+++ b/src/pages/CVPage/CVPage.tsx
@@ -109,7 +109,7 @@ const CvPage: React.FC = () => {
             Chess Club.
           </li>
           <li>
-            Ambassador for GreenPoint Virgin Active Padel; actively participate in padel, running,
+            Ambassador for Epicenter Virgin Active Padel; actively participate in padel, running,
             and football.
           </li>
           <li>Avid F1 fan — participate in F1 Fantasy Game, following motorsport closely.</li>


### PR DESCRIPTION
## Summary
- replace GreenPoint with Epicenter Virgin Active Padel on the About page
- update the same ambassadorship entry on the web CV
- cover both routes with focused tests

Relates to #23.

## Verification
- yarn test: 23 tests passed
- yarn build: passed
- changed files pass Prettier
- yarn prettify: still reports unrelated pre-existing formatting differences across the repository

## Remaining check
The repository contains only the generated GuyGreenCV.pdf and no editable source. A raw text scan could not conclusively inspect its compressed content, so the downloadable PDF still needs manual confirmation or replacement before issue #23 is closed.